### PR TITLE
move dependencies to peerDependencies and set context of callbacks to…

### DIFF
--- a/callback-loader.js
+++ b/callback-loader.js
@@ -5,6 +5,7 @@ var escodegen = require("escodegen");
 module.exports = function (source) {
 	var query = loaderUtils.parseQuery(this.query);
 	var configKey = query.config || 'callbackLoader';
+	var thisModule = this;
 
 	var functions = this.options[configKey];
 	var functionNames = Object.keys(query).filter(function (key) {
@@ -47,7 +48,7 @@ module.exports = function (source) {
 					throw msg;
 				}
 			});
-			var value = functions[funcName].apply(null, args);
+			var value = functions[funcName].apply(thisModule, args);
 			source = replaceIn(source, node.range[0], node.range[1], value.toString());
 			console.log (source);
 		});

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   ],
   "author": "Kreozot",
   "license": "ISC",
-  "dependencies": {
+  "peerDependencies": {
     "ast-query": "^1.0.1",
     "escodegen": "^1.7.0",
-    "loader-utils": "^0.2.11"
+    "loader-utils": "^0.2.11",
+    "webpack": "^1.12.2"
   },
   "devDependencies": {
     "mocha": "^2.3.3",
-    "should": "^7.1.0",
-    "webpack": "^1.12.2"
+    "should": "^7.1.0"
   }
 }


### PR DESCRIPTION
… [increase their potential](https://webpack.github.io/docs/loaders.html)

By passing the loader context to the callbacks you enable things like this one:

``` js
/* webpack.config.js */

module.exports = {
  // ...
  callbackLoader: require('./callbacks'),
  module: {
    preLoaders: [
      {
        test: /\.defrag\.js$/,
        loader: 'callback-loader'
      }
    ],
    loaders: [/* ... */]
  }
}


/* callbacks.js */

var loaderUtils = require("loader-utils");
var path = require('path');
var fs = require("fs");

module.exports = {
  'require.inline': function (file) {
    var absolutePath = path.resolve(this.context, file);
    return fs.readFileSync(absolutePath, "utf8").toString();
  }
}


/* somewhere in any required source file (parsing only files matching *.defrag.js
   for better performance and lack of es6 support) */

require.inline('./anyotherfile.js')
```
